### PR TITLE
Aditional path info for groovy config load

### DIFF
--- a/jenkins/build/Jenkinsfile
+++ b/jenkins/build/Jenkinsfile
@@ -11,7 +11,14 @@ library identifier: "${LIB_NAME}@${LIB_BRANCH}",
 
 node {
 
-  def config = load "../workspace@script/2997395fec659f26f4b3b2a595859b3985578c039148f9c67f66b50d93985cfb/jenkins/${PIPELINE_NAME}/config.groovy"
+  stage("Init") {
+    script {
+      dir(''){
+        checkout scm
+        config = load "jenkins/${PIPELINE_NAME}/config.groovy"
+      }
+    }
+  }
 
   config.BUILDS.each {
     stage("Build ${it}") {

--- a/jenkins/build/Jenkinsfile
+++ b/jenkins/build/Jenkinsfile
@@ -11,7 +11,7 @@ library identifier: "${LIB_NAME}@${LIB_BRANCH}",
 
 node {
 
-  def config = load "../workspace@script/jenkins/${PIPELINE_NAME}/config.groovy"
+  def config = load "../workspace@script/2997395fec659f26f4b3b2a595859b3985578c039148f9c67f66b50d93985cfb/jenkins/${PIPELINE_NAME}/config.groovy"
 
   config.BUILDS.each {
     stage("Build ${it}") {


### PR DESCRIPTION
Changes:
- add extra path info to `Jenkinsfile`

This change addresses the [build error](https://jenkins-90a666-tools.apps.silver.devops.gov.bc.ca/job/90a666-tools/job/90a666-tools-build-pipeline/379/console) found in the Jenkins build pipeline. This issue is similar to one we have seen in the past with other [applications](https://github.com/bcgov/representation-grant-app/blob/main/jenkins/api/Jenkinsfile#L125). 